### PR TITLE
sync testing

### DIFF
--- a/Test_Casts/test.spell
+++ b/Test_Casts/test.spell
@@ -1,0 +1,1 @@
+echo "Hello World!"


### PR DESCRIPTION
This pull request includes several changes to improve the handling of file encoding and the robustness of the spell installation process in the `magi_cli` project. The most important changes include adding UTF-8 encoding to file operations, ensuring the presence of an `__init__.py` file, and adding error handling and verification steps during spell installation.

Improvements to file handling:

* [`magi_cli/spells/ponder.py`](diffhunk://#diff-d8fdd9e70c7d204b68b0407c0ff7079dc9771324a962847dcf64339fa9f7856aL121-R128): Added UTF-8 encoding to file operations in the `install_spell`, `save_to_orb`, and `sync_spells` methods to ensure proper handling of text files. [[1]](diffhunk://#diff-d8fdd9e70c7d204b68b0407c0ff7079dc9771324a962847dcf64339fa9f7856aL121-R128) [[2]](diffhunk://#diff-d8fdd9e70c7d204b68b0407c0ff7079dc9771324a962847dcf64339fa9f7856aL196-R211) [[3]](diffhunk://#diff-d8fdd9e70c7d204b68b0407c0ff7079dc9771324a962847dcf64339fa9f7856aL238-R253)

Robustness enhancements:

* [`magi_cli/spells/ponder.py`](diffhunk://#diff-d8fdd9e70c7d204b68b0407c0ff7079dc9771324a962847dcf64339fa9f7856aL121-R128): Added a check to create an empty `__init__.py` file if it doesn't exist in the spells directory during spell installation.
* [`magi_cli/spells/ponder.py`](diffhunk://#diff-d8fdd9e70c7d204b68b0407c0ff7079dc9771324a962847dcf64339fa9f7856aL132-R157): Enhanced the `install_spell` method to verify that the spell is correctly imported after installation and added error handling for potential issues when updating the RECORD file.

Additionally, a small change was made to a test file:

* [`Test_Casts/test.spell`](diffhunk://#diff-4289d996e636098cb42035f4b28b15297ec3ca64e9386155dcc5a84b101e4f2dR1): Added a simple echo statement for testing purposes.